### PR TITLE
Statically link runtime distributable

### DIFF
--- a/includes/BytesToString/src/BytesToString/BytesToString.vcxproj
+++ b/includes/BytesToString/src/BytesToString/BytesToString.vcxproj
@@ -107,6 +107,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This will embed the runtime libraries in the dll module.