### PR TITLE
Add other EE DLLs to Wine overrides

### DIFF
--- a/SH2EE-web-installer.iss
+++ b/SH2EE-web-installer.iss
@@ -560,7 +560,11 @@ begin
   if IsWine then
   begin
     RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'd3d8', 'native,builtin');
-    MsgBox('Wine detected' #13#13 'This installation was ran in Wine.' #13#13 'The "d3d8" DLL has automatically been set to "native, builtin" in the Wine configuration options. For more information, see https://wiki.winehq.org/Wine_User%27s_Guide#DLL_Overrides', mbInformation, MB_OK);
+    RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'Dinput', 'native,builtin');
+    RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'Dinput8', 'native,builtin');
+    RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'dsound', 'native,builtin');
+    RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'XInput1_3', 'native,builtin');
+    MsgBox('Wine detected' #13#13 'This installation was ran in Wine.' #13#13 'The Silent Hill 2: Enhanced Edition DLLs have automatically been set to "native, builtin" in the Wine configuration options. For more information, see https://wiki.winehq.org/Wine_User%27s_Guide#DLL_Overrides', mbInformation, MB_OK);
   end;
 end;
 


### PR DESCRIPTION
This is a continution of the last request https://github.com/nipkownix/SH2EE-web-installer/pull/2. It adds the remaining DLLs that SH2EE uses to the Wine DLL overrides. dsoal-aldrv.dll is not included as that is not a system DLL. Setting these seemingly has no adverse effects and enables the use of the new dsound system. See comparisons here https://github.com/elishacloud/Silent-Hill-2-Enhancements/issues/505#issuecomment-1186173838