### PR TITLE
Few small changes

### DIFF
--- a/CustomUninstall.iss
+++ b/CustomUninstall.iss
@@ -25,8 +25,6 @@ begin
   DeleteFile(path + '\Dinput8.dll');
   DeleteFile(path + '\dsoal-aldrv.dll');
   DeleteFile(path + '\dsound.dll');
-  DeleteFile(path + '\keyconf.dat');
-  DeleteFile(path + '\local.fix');
   DeleteFile(path + '\SH2EEsetup.dat');
   DeleteFile(path + '\SH2EEconfig.exe');
   DeleteFile(path + '\SH2EEconfig.xml');

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-This is a web installer for [Silent Hill 2: Enhanced Edition](http://www.enhanced.townofsilenthill.com/SH2/), originally created for learning purposes only, and later becoming an actual component of the project.
+This is a web installer for [Silent Hill 2: Enhanced Edition](http://enhanced.townofsilenthill.com/SH2/), originally created for learning purposes only, and later becoming an actual component of the project.
 
 The source code is here for archival and reference purposes.
 

--- a/SH2EE-web-installer.iss
+++ b/SH2EE-web-installer.iss
@@ -2,7 +2,7 @@
 
 #define INSTALLER_VER  "1.0.5"
 #define DEBUG          "false"
-#define SH2EE_CSV_URL  "http://enhanced.townofsilenthill.com/SH2/files/_sh2ee.csv"
+#define SH2EE_CSV_URL  "http://files.townofsilenthill.com/SH2EE/_sh2ee.csv"
 #define LOCAL_REPO     "E:\Porgrams\git_repos\SH2EE-web-installer\"
 
 #define PROJECT_URL      "http://enhanced.townofsilenthill.com/SH2/"

--- a/SH2EE-web-installer.iss
+++ b/SH2EE-web-installer.iss
@@ -2,7 +2,7 @@
 
 #define INSTALLER_VER  "1.0.5"
 #define DEBUG          "false"
-#define SH2EE_CSV_URL  "http://www.enhanced.townofsilenthill.com/SH2/files/_sh2ee.csv"
+#define SH2EE_CSV_URL  "http://enhanced.townofsilenthill.com/SH2/files/_sh2ee.csv"
 #define LOCAL_REPO     "E:\Porgrams\git_repos\SH2EE-web-installer\"
 
 #define PROJECT_URL      "http://enhanced.townofsilenthill.com/SH2/"


### PR DESCRIPTION
Removed keyconfig.dat and local.fix from list of files that are uninstalled. These files are useful and can still be used by vanilla SH2 PC.

Removed "www." from project URLs. I have added an SSL to the site and have redirects in place to remove any "www." from URLs.

Changed .csv URL to a totally new path. This is for future prep as I will be migrating package files to this new subdomain. This was done as the SSL (with .htaccess redirects) was conflicting with the CDN I activated for the site. Moving forward, the CDN will only affect files.townofsilenthill.com so the SSL can work without conflict for enhanced.townofsilenthill.com. Since the download files will be moved to files.townofsilenthill.com, they theoretically should still benefit from CDN download speeds.