### PR TITLE
Add help text for steamos users, remove wine link.

### DIFF
--- a/languages/English.iss
+++ b/languages/English.iss
@@ -81,7 +81,7 @@ MaintenanceLabelUpdate         =Check and download updates for installed enhance
 MaintenanceLabelAdjust         =Open the Silent Hill 2: Enhanced Edition Configuration Tool to adjust project settings for the game.
 MaintenanceLabelUninstall      =Remove all installed enhancement packages. This only removes the Silent Hill 2: Enhanced Edition project files and does not remove Silent Hill 2 PC files.
 ; For translators: you can find Wine's official translations here: https://gitlab.winehq.org/wine/wine/-/tree/master/po
-WineDetected                   =Wine detected%n%nThis installation was ran in Wine.%n%nThe Silent Hill 2: Enhanced Edition DLLs have automatically been set to "native, builtin" in the Wine configuration options.%n%nFor more information, see https://wiki.winehq.org/Wine_User%27s_Guide#DLL_Overrides
+WineDetected                   =Wine/Proton detected%n%nThis installation is running in Wine/Proton.%n%nThe Silent Hill 2: Enhanced Edition DLLs have automatically been set to "native, builtin" in the Wine configuration options.%n%nFor Steam Deck/OS users: This setting is only active for the currently used profile.%nIf you added this installer as a non-steam game, simply change its target from SH2EEsetup.exe to sh2pc.exe and use that to start the game.
 GameFilesNotFound              =The selected folder may not be where Silent Hill 2 PC is located.%n%nProceed anyway?
 installPageDescriptionLabel    =Please select which enhancement packages you would like to install or repair.
 installSelectComponentsLabel   =Silent Hill 2: Enhanced Edition is comprised of several enhancement packages. Select which enhancement packages you wish to install. For the full, intended experience, install all enhancement packages.


### PR DESCRIPTION
The link to winehq.org cannot be clicked or copied,
thus I removed it. Instead I added a text that should
help steamOS users to keep the override for the game.